### PR TITLE
Add tests module and a simple test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A short summary of the various folders in this repository is as follows:
 - `scripts`: example code for how to benchmark a model on a dataset
 - `src/qml_benchmarks`: a simple Python package defining quantum and classical models, 
    as well as data generating functions
+- `tests`: tests for the `qml_benchmarks` Python package.
 
 ## Installation
 

--- a/src/qml_benchmarks/models/__init__.py
+++ b/src/qml_benchmarks/models/__init__.py
@@ -36,11 +36,13 @@ from qml_benchmarks.models.iqp_variational import IQPVariationalClassifier
 from qml_benchmarks.models.projected_quantum_kernel import ProjectedQuantumKernel
 from qml_benchmarks.models.quantum_boltzmann_machine import (
     QuantumBoltzmannMachine,
-    QuantumBoltzmannMachineSeparable
+    QuantumBoltzmannMachineSeparable,
 )
 from qml_benchmarks.models.quantum_kitchen_sinks import QuantumKitchenSinks
 from qml_benchmarks.models.quantum_metric_learning import QuantumMetricLearner
-from qml_benchmarks.models.quanvolutional_neural_network import QuanvolutionalNeuralNetwork
+from qml_benchmarks.models.quanvolutional_neural_network import (
+    QuanvolutionalNeuralNetwork,
+)
 from qml_benchmarks.models.separable import (
     SeparableVariationalClassifier,
     SeparableKernelClassifier,
@@ -83,30 +85,30 @@ __all__ = [
 
 class MLPClassifier(MLP):
     def __init__(
-            self,
-            hidden_layer_sizes=(100, 100),
-            activation="relu",
-            solver="adam",
-            alpha=0.0001,
-            batch_size="auto",
-            learning_rate="constant",
-            learning_rate_init=0.001,
-            power_t=0.5,
-            max_iter=3000,
-            shuffle=True,
-            random_state=None,
-            tol=1e-4,
-            verbose=False,
-            warm_start=False,
-            momentum=0.9,
-            nesterovs_momentum=True,
-            early_stopping=False,
-            validation_fraction=0.1,
-            beta_1=0.9,
-            beta_2=0.999,
-            epsilon=1e-8,
-            n_iter_no_change=10,
-            max_fun=15000,
+        self,
+        hidden_layer_sizes=(100, 100),
+        activation="relu",
+        solver="adam",
+        alpha=0.0001,
+        batch_size="auto",
+        learning_rate="constant",
+        learning_rate_init=0.001,
+        power_t=0.5,
+        max_iter=200,
+        shuffle=True,
+        random_state=None,
+        tol=1e-4,
+        verbose=False,
+        warm_start=False,
+        momentum=0.9,
+        nesterovs_momentum=True,
+        early_stopping=False,
+        validation_fraction=0.1,
+        beta_1=0.9,
+        beta_2=0.999,
+        epsilon=1e-8,
+        n_iter_no_change=10,
+        max_fun=15000,
     ):
         super().__init__(
             hidden_layer_sizes=hidden_layer_sizes,
@@ -137,16 +139,16 @@ class MLPClassifier(MLP):
 
 class SVC(SVC_base):
     def __init__(
-            self,
-            C=1.0,
-            degree=3,
-            gamma="scale",
-            coef0=0.0,
-            shrinking=True,
-            probability=False,
-            tol=0.001,
-            max_iter=-1,
-            random_state=None,
+        self,
+        C=1.0,
+        degree=3,
+        gamma="scale",
+        coef0=0.0,
+        shrinking=True,
+        probability=False,
+        tol=0.001,
+        max_iter=-1,
+        random_state=None,
     ):
         super().__init__(
             C=C,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,35 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for model definitions"""
+
+import sys
+
+import pytest
+from qml_benchmarks.models import MLPClassifier
+from sklearn.utils.estimator_checks import parametrize_with_checks
+
+
+@parametrize_with_checks(
+    [
+        MLPClassifier(),
+    ]
+)
+def test_classification_models(estimator, check):
+    """Test estimator outputs, trainablitity and compatiblity with Scikit-learn API."""
+    check(estimator)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main())


### PR DESCRIPTION
As per #11, we should test that the model definitions and data generating functions work as we add new models and data. The test suite can be automatically run as part of a Github workflow when new PRs are submitted or locally. This PR adds a test module with sklearn's testing functionality that runs a suite of tests on an estimator (see list in [sklearn.utils.estimator_checks](https://github.com/scikit-learn/scikit-learn/blob/70fdc843a4b8182d97a3508c1a426acc5e87e980/sklearn/utils/estimator_checks.py#L149)).

Some of these tests might fail for quantum models and we can have more fine-grained control as we develop the testing suite.  But as a start, we can just run the full test suite for all classifiers starting from the MLPClassifier. I had to modify the `max_iter` to make the tests pass.

