### PR TITLE
Fix RBM initialization

### DIFF
--- a/src/qml_benchmarks/models/__init__.py
+++ b/src/qml_benchmarks/models/__init__.py
@@ -81,7 +81,7 @@ __all__ = [
     "MLPClassifier",
     "SVC",
     "DeepEBM",
-    "RBM",
+    "RestrictedBoltzmannMachine",
 ]
 
 

--- a/src/qml_benchmarks/models/energy_based_model.py
+++ b/src/qml_benchmarks/models/energy_based_model.py
@@ -76,7 +76,7 @@ class RestrictedBoltzmannMachine(BernoulliRBM, BaseGenerator):
         n_iter=10,
         verbose=0,
         random_state=None,
-        score_fn='mmd',
+        score_fn='pseudolikelihood',
         mmd_kwargs ={'n_samples': 1000, 'sigma': 1.0}
     ):
         super().__init__(

--- a/src/qml_benchmarks/models/energy_based_model.py
+++ b/src/qml_benchmarks/models/energy_based_model.py
@@ -76,7 +76,7 @@ class RestrictedBoltzmannMachine(BernoulliRBM, BaseGenerator):
         n_iter=10,
         verbose=0,
         random_state=None,
-        score_fn='pseudolikelihood',
+        score_fn='mmd',
         mmd_kwargs ={'n_samples': 1000, 'sigma': 1.0}
     ):
         super().__init__(
@@ -90,11 +90,14 @@ class RestrictedBoltzmannMachine(BernoulliRBM, BaseGenerator):
         self.score_fn = score_fn
         self.mmd_kwargs = mmd_kwargs
 
-    def initialize(self, x: any = None):
-        self.fit(x[:1, ...])
-        if len(x.shape) > 2:
+    def initialize(self, X: any = None):
+        if len(X.shape) > 2:
             raise ValueError("Input data must be 2D")
-        self.dim = x.shape[1]
+        self.dim = X.shape[1]
+
+    def fit(self, X, y=None):
+        self.initialize(X)
+        super().fit(X, y)
 
     # Gibbs sampling:
     def _sample(self, num_steps=1000):
@@ -128,4 +131,7 @@ class RestrictedBoltzmannMachine(BernoulliRBM, BaseGenerator):
         if self.score_fn == 'pseudolikelihood':
             return float(np.mean(super().score_samples(X)))
         elif self.score_fn == 'mmd':
-            return float(-mmd_loss(X, self.sample(self.mmd_kwargs['n_samples']), self.mmd_kwargs['sigma']))
+            sigma = self.mmd_kwargs['sigma']
+            sigmas = [sigma] if isinstance(sigma, (int, float)) else sigma
+            score = np.mean([mmd_loss(X, self.sample(self.mmd_kwargs['n_samples']), sigma) for sigma in sigmas])
+            return float(-score)

--- a/src/qml_benchmarks/models/energy_based_model.py
+++ b/src/qml_benchmarks/models/energy_based_model.py
@@ -77,7 +77,7 @@ class RestrictedBoltzmannMachine(BernoulliRBM, BaseGenerator):
         verbose=0,
         random_state=None,
         score_fn='pseudolikelihood',
-        mmd_kwargs ={'n_samples': 1000, 'sigma': 1.0}
+        mmd_kwargs ={'n_samples': 1000, 'n_steps': 1000, 'sigma': 1.0}
     ):
         super().__init__(
             n_components=n_components,
@@ -133,5 +133,6 @@ class RestrictedBoltzmannMachine(BernoulliRBM, BaseGenerator):
         elif self.score_fn == 'mmd':
             sigma = self.mmd_kwargs['sigma']
             sigmas = [sigma] if isinstance(sigma, (int, float)) else sigma
-            score = np.mean([mmd_loss(X, self.sample(self.mmd_kwargs['n_samples']), sigma) for sigma in sigmas])
+            score = np.mean([mmd_loss(X, self.sample(self.mmd_kwargs['n_samples'],
+                                                     self.mmd_kwargs['n_steps']), sigma) for sigma in sigmas])
             return float(-score)


### PR DESCRIPTION
Realized there was an error in the design of the RestrictedBoltzmannMachine. The class was calling fit from the inherited sklearn RBM, but this method does not call initialize so the attribute self.dim was not set. This leads to problems in hyperparameter opt that involve scores that need sampling (like MMD), since the pipeline will not call initialize.

The fix overwrites the fit method and calls initialize. 