### PR TITLE
Change devices from `default.qubit.jax` to `default.qubit`

### DIFF
--- a/src/qml_benchmarks/models/circuit_centric.py
+++ b/src/qml_benchmarks/models/circuit_centric.py
@@ -34,7 +34,7 @@ class CircuitCentricClassifier(BaseEstimator, ClassifierMixin):
         jit=True,
         scaling=1.0,
         random_state=42,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit"},
     ):
         r"""
@@ -75,7 +75,7 @@ class CircuitCentricClassifier(BaseEstimator, ClassifierMixin):
             max_vmap (int or None): The maximum size of a chunk to vectorise over. Lower values use less memory.
                 must divide batch_size.
             jit (bool): Whether to use just in time compilation.
-            dev_type (str): Pennylane device type; e.g. 'default.qubit.jax'.
+            dev_type (str): Pennylane device type; e.g. 'default.qubit'.
             qnode_kwargs (str): Keyword arguments for the circuit qnode.
             scaling (float): Factor by which to scale the input data.
             random_state (int): Seed used for pseudorandom number generation.

--- a/src/qml_benchmarks/models/data_reuploading.py
+++ b/src/qml_benchmarks/models/data_reuploading.py
@@ -39,7 +39,7 @@ class DataReuploadingClassifier(BaseEstimator, ClassifierMixin):
         max_vmap=None,
         jit=True,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit"},
         random_state=42,
     ):

--- a/src/qml_benchmarks/models/dressed_quantum_circuit.py
+++ b/src/qml_benchmarks/models/dressed_quantum_circuit.py
@@ -29,7 +29,7 @@ class DressedQuantumCircuitClassifier(BaseEstimator, ClassifierMixin):
         jit=True,
         max_steps=100000,
         convergence_interval=200,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit"},
         scaling=1.0,
         random_state=42,

--- a/src/qml_benchmarks/models/iqp_kernel.py
+++ b/src/qml_benchmarks/models/iqp_kernel.py
@@ -35,7 +35,7 @@ class IQPKernelClassifier(BaseEstimator, ClassifierMixin):
         random_state=42,
         scaling=1.0,
         max_vmap=250,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit", "diff_method": None},
     ):
         r"""

--- a/src/qml_benchmarks/models/iqp_variational.py
+++ b/src/qml_benchmarks/models/iqp_variational.py
@@ -32,7 +32,7 @@ class IQPVariationalClassifier(BaseEstimator, ClassifierMixin):
         convergence_interval=200,
         random_state=42,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax"},
     ):
         r"""

--- a/src/qml_benchmarks/models/projected_quantum_kernel.py
+++ b/src/qml_benchmarks/models/projected_quantum_kernel.py
@@ -37,7 +37,7 @@ class ProjectedQuantumKernel(BaseEstimator, ClassifierMixin):
         jit=True,
         max_vmap=None,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit", "diff_method": None},
         random_state=42,
     ):

--- a/src/qml_benchmarks/models/quantum_kitchen_sinks.py
+++ b/src/qml_benchmarks/models/quantum_kitchen_sinks.py
@@ -35,7 +35,7 @@ class QuantumKitchenSinks(BaseEstimator, ClassifierMixin):
         var=1.0,
         jit=True,
         max_vmap=None,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax", "diff_method": None},
         scaling=1.0,
         random_state=42,

--- a/src/qml_benchmarks/models/quantum_metric_learning.py
+++ b/src/qml_benchmarks/models/quantum_metric_learning.py
@@ -54,7 +54,7 @@ class QuantumMetricLearner(BaseEstimator, ClassifierMixin):
         jit=True,
         random_state=42,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit"},
     ):
         """

--- a/src/qml_benchmarks/models/quanvolutional_neural_network.py
+++ b/src/qml_benchmarks/models/quanvolutional_neural_network.py
@@ -81,7 +81,7 @@ class QuanvolutionalNeuralNetwork(BaseEstimator, ClassifierMixin):
         batch_size=32,
         random_state=42,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit"},
     ):
         r"""

--- a/src/qml_benchmarks/models/separable.py
+++ b/src/qml_benchmarks/models/separable.py
@@ -34,7 +34,7 @@ class SeparableVariationalClassifier(BaseEstimator, ClassifierMixin):
         random_state=42,
         scaling=1.0,
         convergence_interval=200,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax"},
     ):
         r"""
@@ -249,7 +249,7 @@ class SeparableKernelClassifier(BaseEstimator, ClassifierMixin):
         jit=True,
         random_state=42,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax", "diff_method": None},
     ):
         r"""

--- a/src/qml_benchmarks/models/tree_tensor.py
+++ b/src/qml_benchmarks/models/tree_tensor.py
@@ -35,7 +35,7 @@ class TreeTensorClassifier(BaseEstimator, ClassifierMixin):
         max_vmap=None,
         jit=True,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit"},
     ):
         r"""

--- a/src/qml_benchmarks/models/vanilla_qnn.py
+++ b/src/qml_benchmarks/models/vanilla_qnn.py
@@ -34,7 +34,7 @@ class VanillaQNN(BaseEstimator, ClassifierMixin):
         convergence_threshold=1e-6,
         random_state=42,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax"},
     ):
         """

--- a/src/qml_benchmarks/models/weinet.py
+++ b/src/qml_benchmarks/models/weinet.py
@@ -36,7 +36,7 @@ class WeiNet(BaseEstimator, ClassifierMixin):
         max_vmap=None,
         jit=True,
         scaling=1.0,
-        dev_type="default.qubit.jax",
+        dev_type="default.qubit",
         qnode_kwargs={"interface": "jax-jit"},
         batch_size=32,
     ):


### PR DESCRIPTION
The explicit use of the jax device is now discouraged in PennyLane.

I tested a few models and didn't get any issues, but haven't done comprehensive testing.